### PR TITLE
Fix ESM import resolution in dist/index.js

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,11 +1,10 @@
-import type { PlaywrightTestConfig } from '@playwright/test';
-import { devices } from '@playwright/test';
+import { defineConfig, devices } from '@playwright/test';
 
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
 
-const config: PlaywrightTestConfig = {
+const config = defineConfig({
   testDir: './tests',
   /* Maximum time one test can run for. */
   timeout: 30 * 1000,
@@ -41,6 +40,6 @@ const config: PlaywrightTestConfig = {
       },
     },
   ],
-};
+});
 
 export default config;

--- a/src/base.ts
+++ b/src/base.ts
@@ -1,3 +1,20 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'fs';
 import process from 'process';
 
 // Code copied from the Playwright codebase because it's not exported
@@ -16,4 +33,10 @@ export function monotonicTime(): number {
 export const ansiRegex = new RegExp('([\\u001B\\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?\\u0007)|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-ntqry=><~])))', 'g');
 export function stripAnsiEscapes(str: string): string {
   return str.replace(ansiRegex, '');
+}
+
+export async function removeFolders(dirs: string[]): Promise<(Error| undefined)[]> {
+  return await Promise.all(dirs.map((dir: string) =>
+    fs.promises.rm(dir, { recursive: true, force: true, maxRetries: 10 }).catch(e => e)
+  ));
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ import fs from 'fs';
 import path from 'path';
 
 import type { FullConfig, FullResult, Reporter, Suite, TestCase } from '@playwright/test/reporter';
-import { assert, monotonicTime, stripAnsiEscapes } from './base';
+import { assert, monotonicTime, stripAnsiEscapes } from './base.js';
 
 type SonarReporterOptions = { outputFile?: string, stripANSIControlSequences?: boolean, sonarcloud?: boolean };
 

--- a/tests/playwright-test-fixtures.ts
+++ b/tests/playwright-test-fixtures.ts
@@ -19,7 +19,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { PNG } from 'playwright-core/lib/utilsBundle';
-import { removeFolders } from 'playwright-core/lib/utils';
+import { removeFolders } from '../dist/base.js';
 import type { CommonFixtures, CommonWorkerFixtures, TestChildProcess } from './config/commonFixtures.js';
 import { commonFixtures } from './config/commonFixtures.js';
 import type { ServerFixtures, ServerWorkerOptions } from './config/serverFixtures.js';
@@ -113,7 +113,7 @@ async function runPlaywrightTest(childProcess: CommonFixtures['childProcess'], b
   // eslint-disable-next-line prefer-const
   let { exitCode, output } = await runPlaywrightCommand(childProcess, cwd, args, {
     // PW_TEST_REPORTER: path.join(__dirname, '../../packages/playwright-test/lib/reporters/json.js'),
-    PW_TEST_REPORTER: path.join(__dirname, '../node_modules/playwright/lib/reporters/json.js'),
+    PW_TEST_REPORTER: 'json',
     // PW_TEST_REPORTER: path.join(__dirname, '../dist/index.js'),
     PLAYWRIGHT_JSON_OUTPUT_NAME: reportFile,
     ...env,


### PR DESCRIPTION
This PR fixes the `ERR_MODULE_NOT_FOUND` error reported in #33 when using v0.5.0 in ESM mode.

The generated build was importing `./base` from `dist/index.js`, which breaks Node ESM resolution because the `.js` extension is required. Updating the import to `./base.js` restores compatibility and makes the package work correctly when consumed by Playwright.

**Changes**

- Update the ESM import in `src/index.ts` to include the `.js` extension
- Keep the published build compatible with Node ESM resolution rules

**Related**

Closes #33